### PR TITLE
Update go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/TroutSoftware/sqlite
 
-go 1.21.4
+go 3.24.1
 
 require (
 	github.com/google/go-cmp v0.6.0


### PR DESCRIPTION
Affected versions of go 1.21.4 are vulnerable to URL Redirection to Untrusted Site ('Open Redirect') in the login page when sign in.