### PR TITLE
Update go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/TroutSoftware/sqlite
 
-go 1.21.4
+go 1.23.0
 
 require (
 	github.com/google/go-cmp v0.6.0


### PR DESCRIPTION
go 1,21,4 has many vulns that should be updated with latest version.  https://www.cvedetails.com/vulnerability-list/vendor_id-14185/product_id-29205/version_id-1724709/Golang-GO-1.21.4.html?page=1&order=1&trc=4&sha=ca0a97a47308628a47ed5436642e65ab6c2b706a